### PR TITLE
Generic cache

### DIFF
--- a/get-started/Fine-tuning-BERT.ipynb
+++ b/get-started/Fine-tuning-BERT.ipynb
@@ -1626,7 +1626,7 @@
    "outputs": [],
    "source": [
     "!mkdir /tmp/exe_cache\n",
-    "!ln -s /graphcore/exe_cache/12985422070302931263.popef /tmp/exe_cache"
+    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache"
    ]
   },
   {
@@ -2053,7 +2053,8 @@
    },
    "outputs": [],
    "source": [
-    "!ln -s /graphcore/exe_cache/10825557225208313664.popef /tmp/exe_cache"
+    "# This gets skipped since the entire cache with the train and validation was loaded in the previous section.\n",
+    "# !ln -s /graphcore/exe_cache/* /tmp/exe_cache"
    ]
   },
   {

--- a/get-started/Fine-tuning-BERT.ipynb
+++ b/get-started/Fine-tuning-BERT.ipynb
@@ -1625,8 +1625,8 @@
    },
    "outputs": [],
    "source": [
-    "!mkdir /tmp/exe_cache\n",
-    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache"
+    "!mkdir -p /tmp/exe_cache\n",
+    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache/"
    ]
   },
   {
@@ -2054,7 +2054,7 @@
    "outputs": [],
    "source": [
     "# This gets skipped since the entire cache with the train and validation was loaded in the previous section.\n",
-    "# !ln -s /graphcore/exe_cache/* /tmp/exe_cache"
+    "# !ln -s /graphcore/exe_cache/* /tmp/exe_cache/"
    ]
   },
   {


### PR DESCRIPTION
Change executable cache loading to a generic folder
- load entire exe_cache with all `.popef` so binary doesn't have to be hard-coded
- ensures path to exe_cach parent folders are created