### PR TITLE
Add symlink timeout

### DIFF
--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -14,6 +14,7 @@ symlink-public-resources() {
         ((COUNTER++))
         if [ $COUNTER -eq 300 ]; then
             echo "Warning! Abandoning symlink - source Dataset ${public_source_dir} has not been mounted & populated after 5m."
+            return
         fi
     done
 

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -5,10 +5,13 @@ symlink-public-resources() {
     target_dir=${2}
 
     # need to wait until the dataset has been mounted (async on Paperspace's end)
-    while [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ]
+    COUNTER=0
+    # set a timeout of 300s/5m for the while loop as a safety measure
+    while [ $COUNTER -lt 300 ] && ( [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ] )
     do
         echo "Waiting for dataset "${public_source_dir}" to be mounted..."
         sleep 1
+        ((COUNTER++))
     done
 
     echo "Symlinking - ${public_source_dir} to ${target_dir}"

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -42,7 +42,7 @@ echo "Starting preparation of datasets"
 exe_cache_source_dir="${PUBLIC_DATASET_DIR}/poplar-executables-pytorch-3-1"
 symlink-public-resources "${exe_cache_source_dir}" $POPLAR_EXECUTABLE_CACHE_DIR
 # Symlink squad
-symlink-public-resources "${PUBLIC_DATASET_DIR}/squad2" "${HF_DATASETS_CACHE}/squad"
+symlink-public-resources "${PUBLIC_DATASET_DIR}/squad" "${HF_DATASETS_CACHE}/squad"
 # Symlink OGB Wiki dataset and checkpoint
 symlink-public-resources "${PUBLIC_DATASET_DIR}/ogbl_wikikg2_custom" "${DATASET_DIR}/ogbl_wikikg2_custom"
 

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -12,6 +12,9 @@ symlink-public-resources() {
         echo "Waiting for dataset "${public_source_dir}" to be mounted..."
         sleep 1
         ((COUNTER++))
+        if [ $COUNTER -eq 300 ]; then
+            echo "Warning! Abandoning symlink - source Dataset ${public_source_dir} has not been mounted & populated after 5m."
+        fi
     done
 
     echo "Symlinking - ${public_source_dir} to ${target_dir}"

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -41,7 +41,7 @@ echo "Starting preparation of datasets"
 exe_cache_source_dir="${PUBLIC_DATASET_DIR}/poplar-executables-pytorch-3-1"
 symlink-public-resources "${exe_cache_source_dir}" $POPLAR_EXECUTABLE_CACHE_DIR
 # Symlink squad
-symlink-public-resources "${PUBLIC_DATASET_DIR}/squad" "${HF_DATASETS_CACHE}/squad"
+symlink-public-resources "${PUBLIC_DATASET_DIR}/squad2" "${HF_DATASETS_CACHE}/squad"
 # Symlink OGB Wiki dataset and checkpoint
 symlink-public-resources "${PUBLIC_DATASET_DIR}/ogbl_wikikg2_custom" "${DATASET_DIR}/ogbl_wikikg2_custom"
 


### PR DESCRIPTION
adds a 5 minute timeout to the symlinking while loop. In the unexpected case where the dataset doesn't get mounted, or remains empty, then instead of looping forever, we terminate the loop after 5 minutes. Datasets are usually mounted within a minute, so I thought 5 minutes would be a reasonable timeout, but please suggest a different value if desired. 

Testing performed:
Edited the script to attempt to symlink a non-existing dataset. We were 'waiting for dataset..' for 5 minutes and then successfully broke out of the loop and proceeded with the rest of the script. Other datasets that existed were symlinked/overlays created as usual. 