### PR TITLE
add timeout to symlink while loop

### DIFF
--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -49,11 +49,11 @@ symlink-public-resources "${gptj_cache_source_dir}" "$POPLAR_EXECUTABLE_CACHE_DI
 # Symlink squad
 symlink-public-resources "${PUBLIC_DATASETS_DIR}/squad" "${HF_DATASETS_CACHE}/squad"
 symlink-public-resources "${PUBLIC_DATASETS_DIR}/glue" "${HF_DATASETS_CACHE}/glue"
-# Symlink OGB Wiki dataset and checkpoint
-symlink-public-resources "${PUBLIC_DATASETS_DIR}/ogbl_wikikg2_custom" "${DATASETS_DIR}/ogbl_wikikg2_custom"
 
 # symlink local dataset used by vit-model-training notebook
 symlink-public-resources "${PUBLIC_DATASETS_DIR}/chest-xray-nihcc-3" "${DATASETS_DIR}/chest-xray-nihcc-3"
+# Symlink OGB Wiki dataset and checkpoint
+symlink-public-resources "${PUBLIC_DATASETS_DIR}/ogbl_wikikg2_custom" "${DATASETS_DIR}/ogbl_wikikg2_custom"
 
 # pre-install the correct version of optimum for this release
 python -m pip install "optimum-graphcore>=0.5, <0.6"

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -6,12 +6,19 @@ symlink-public-resources() {
     public_source_dir=${1}
     target_dir=${2}
 
+    local -i COUNTER=0
     # need to wait until the dataset has been mounted (async on Paperspace's end)
-    while [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ]
+    while [ $COUNTER -lt 300 ] && ( [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ] )
     do
         echo "Waiting for dataset "${public_source_dir}" to be mounted..."
         sleep 1
+        ((COUNTER++))
     done
+
+    if [ $COUNTER -eq 300 ]; then
+        echo "Warning! Abandoning symlink - source Dataset ${public_source_dir} has not been mounted & populated after 5m."
+        return
+    fi
 
     echo "Symlinking - ${public_source_dir} to ${target_dir}"
 


### PR DESCRIPTION
This will prevent getting stuck in an infinite while loop if a dataset is not mounted or populated for some reason. Limit is set to 5 minutes. 

Tests done:
Created a Gradient notebook in the Pytorch runtime using this branch, observed in the logs that we were waiting for the `ogbl_wikikg2_custom` dataset to be mounted for 5 minutes before breaking out of that loop and proceeding with the next dataset, and continuing with the rest of `prepare-datasets.sh` as normal. 