### PR TITLE
Use lists of input IDs in GPT-J tokenizer

### DIFF
--- a/gptj-text-generation/GPTJ-generative-inference.ipynb
+++ b/gptj-text-generation/GPTJ-generative-inference.ipynb
@@ -47,8 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "%pip install -r requirements.txt"
+        "%pip install -r requirements.txt"
    ]
   },
   {

--- a/gptj-text-generation/data/mnli_data.py
+++ b/gptj-text-generation/data/mnli_data.py
@@ -80,7 +80,7 @@ class PadCollate:
 
 def tokenizes_text(tokenizer):
     def func(dataset):
-        tokenized = tokenizer(dataset["text"], return_attention_mask=False, return_tensors="np")
+        tokenized = tokenizer(dataset["text"], return_attention_mask=False)
         return tokenized
 
     return func

--- a/gptj-text-generation/finetuning.ipynb
+++ b/gptj-text-generation/finetuning.ipynb
@@ -45,8 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "%pip install -r requirements.txt"
+        "%pip install -r requirements.txt"
    ]
   },
   {


### PR DESCRIPTION
GPT-J is currently not working because the numpy version that gets installed no longer supports ragged arrays. We fix that by making the tokenizer return lists of lists which are then concatenated.

(And drop %%capture)